### PR TITLE
Fixed links to sub-pages in physical_level_lower_level_protocols.md

### DIFF
--- a/physical_level_lower_level_protocols.md
+++ b/physical_level_lower_level_protocols.md
@@ -15,33 +15,21 @@ Level II use the full GUID and can handle more data. This level is useful for no
 Below the implemented transports is described.
 
 
-*  [VSCP over TCP/IP](VSCP over TCP/IP)
-
-*  [VSCP over Ethernet (raw Ethernet)](VSCP over Ethernet (raw Ethernet))
-
-*  [VSCP over UDP](VSCP over UDP)
-
-*  [VSCP over TCP/IP Multicast](VSCP over TCP/IP Multicast)
-
-*  [VSCP websocket](VSCP websocket)
-
-*  [VSCP REST](VSCP REST)
-
-*  [VSCP over CAN (CAN4VSCP)](VSCP over CAN (CAN4VSCP))
-
-*  [VSCP over a serial channel (RS-232)](VSCP over a serial channel (RS-232))
-
-*  [VSCP Level I over RS-485/RS-422](VSCP Level I over RS-485/RS-422)
-
-*  [VSCP over IEEE 802.15.4](VSCP over IEEE 802.15.4)
-
-*  [VSCP Droplet model](VSCP Droplet model)
-
-*  [VSCP BumbleBeez Protocol](VSCP BumbleBeez Protocol)
-
-*  [VSCP over MQTT](VSCP over MQTT)
-
-*  [VSCP Text](VSCP Text)
+*  [VSCP over TCP/IP](./vscp_over_tcp_ip.md)
+*  [VSCP over Ethernet (raw Ethernet)](./vscp_over_ethernet_raw_ethernet.md)
+*  [VSCP over UDP](./vscp_over_udp.md)
+*  [VSCP over TCP/IP Multicast](./vscp_over_tcp_ip_multicast.md)
+*  [VSCP websocket](./vscp_websocket.md)
+*  [VSCP REST](./vscp_rest.md)
+*  [VSCP over CAN (CAN4VSCP)](./vscp_over_can_can4vscp.md)
+*  [VSCP over a serial channel (RS-232)](./vscp_over_a_serial_channel_rs-232.md)
+*  [VSCP Level I over RS-485/RS-422](./vscp_level_i_over_rs-485_rs-422.md)
+*  [VSCP over Bluetooth mesh](./vscp_over_bt_mesh.md)
+*  [VSCP over IEEE 802.15.4](./vscp_over_ieee_802.15.4.md)
+*  [VSCP Droplet model](./vscp_droplet_model.md)
+*  [VSCP BumbleBeez Protocol](./vscp_bumblebeez_protocol.md)
+*  [VSCP over MQTT](./vscp_over_mqtt.md)
+*  [VSCP Text](./vscp_text.md)
 
 
 {% include "./bottom_copyright.md" %}


### PR DESCRIPTION
The links on this page were all broken:
https://grodansparadis.gitbooks.io/the-vscp-specification/physical_level_lower_level_protocols.html

This Pull Request corrects those links.
